### PR TITLE
feat(share): Implement share target functionality

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.techstash">
 
     <application
         android:name=".TechStashApplication"
@@ -18,8 +19,12 @@
             android:theme="@style/Theme.TechStash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/example/techstash/MainActivity.kt
+++ b/app/src/main/java/com/example/techstash/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.example.techstash
 
+
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -17,6 +19,15 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        var initialUrl: String? = null
+        var initialTitle: String? = null
+
+        if (intent?.action == Intent.ACTION_SEND && intent.type == "text/plain") {
+            initialUrl = intent.getStringExtra(Intent.EXTRA_TEXT)
+            initialTitle = intent.getStringExtra(Intent.EXTRA_SUBJECT)
+        }
+
         setContent {
             TechStashTheme {
                 val navController = rememberNavController()
@@ -28,7 +39,11 @@ class MainActivity : ComponentActivity() {
                     composable(
                         route = Screen.MainScreen.route
                     ) {
-                        MainScreen(navController = navController)
+                        MainScreen(
+                            navController = navController,
+                            initialUrl = initialUrl,
+                            initialTitle = initialTitle
+                        )
                     }
 
                     composable(

--- a/app/src/main/java/com/example/techstash/ui/AddArticleDialog.kt
+++ b/app/src/main/java/com/example/techstash/ui/AddArticleDialog.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun AddArticleDialog(
+    initialUrl: String?,
+    initialTitle: String?,
     onDismiss: () -> Unit,
     onConfirm: (url: String, title: String, author: String, memo: String) -> Unit
 ) {
     // 各入力欄の状態を管理するための変数
-    var url by remember { mutableStateOf("") }
-    var title by remember { mutableStateOf("") }
+    var url by remember { mutableStateOf(initialUrl ?: "") }
+    var title by remember { mutableStateOf(initialTitle ?: "") }
     var author by remember { mutableStateOf("") }
     var memo by remember { mutableStateOf("") }
 

--- a/app/src/main/java/com/example/techstash/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/techstash/ui/MainScreen.kt
@@ -26,11 +26,13 @@ import com.example.techstash.ui.navigation.Screen
 @Composable
 fun MainScreen(
     viewModel: ArticleViewModel = hiltViewModel(),
-    navController: NavController
+    navController: NavController,
+    initialUrl: String?,
+    initialTitle: String?,
 ) {
     val articles by viewModel.allArticles.collectAsState()
 
-    var showDialog by remember { mutableStateOf(false) }
+    var showDialog by remember { mutableStateOf(initialUrl != null) }
 
     Scaffold(
         topBar = {
@@ -59,6 +61,8 @@ fun MainScreen(
 
         if (showDialog) {
             AddArticleDialog(
+                initialUrl = initialUrl,
+                initialTitle = initialTitle,
                 onDismiss = { showDialog = false },
                 onConfirm = { url, title, author, memo ->
                     viewModel.insert(url, title, author, memo)


### PR DESCRIPTION
- Add ACTION_SEND intent-filter to AndroidManifest.
- Handle incoming text/plain intents in MainActivity to extract URL and Title.
- Pass initial data to MainScreen and AddArticleDialog.
- Automatically open the "Add Article" dialog when app is launched via share.

fixes #21